### PR TITLE
Adjust default resource limits for container

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -52,14 +52,18 @@ RUN mkdir -p $VSCODE_USER $VSCODE_EXTENSIONS
 COPY  --chown=coder:coder settings/ $VSCODE_USER
 
 # Java Extensions
+ARG VSCODE_JAVA_VERSION=0.45.0
+ARG VSCODE_JAVA_DEBUG_VERSION=0.18.0
+ARG VSCODE_JAVA_TEST_VERSION=0.16.0
+
 RUN mkdir -p ${VSCODE_EXTENSIONS}/java \
-    && curl -JLs --retry 5 https://marketplace.visualstudio.com/_apis/public/gallery/publishers/redhat/vsextensions/java/latest/vspackage | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java extension
+    && curl -JLs --retry 5 https://github.com/redhat-developer/vscode-java/releases/download/v${VSCODE_JAVA_VERSION}/redhat.java-${VSCODE_JAVA_VERSION}.vsix | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java extension
 
 RUN mkdir -p ${VSCODE_EXTENSIONS}/java-debugger \
-    && curl -JLs --retry 5 https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-debug/latest/vspackage | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java-debugger extension
+    && curl -JLs --retry 5 https://github.com/microsoft/vscode-java-debug/releases/download/${VSCODE_JAVA_DEBUG_VERSION}/vscode-java-debug-${VSCODE_JAVA_DEBUG_VERSION}.vsix | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java-debugger extension
 
 RUN mkdir -p ${VSCODE_EXTENSIONS}/java-test \
-    && curl -JLs --retry 5 https://marketplace.visualstudio.com/_apis/public/gallery/publishers/vscjava/vsextensions/vscode-java-test/latest/vspackage | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java-test extension
+    && curl -JLs --retry 5 https://github.com/microsoft/vscode-java-test/releases/download/${VSCODE_JAVA_TEST_VERSION}/vscjava.vscode-java-test-${VSCODE_JAVA_TEST_VERSION}.vsix | bsdtar --strip-components=1 -xf - -C ${VSCODE_EXTENSIONS}/java-test extension
 
 # Custom Sonar lint with Java support
 COPY --chown=coder:coder sonarlint-vscode-1.7.0-SNAPSHOT.vsix .

--- a/ide/settings/settings.json
+++ b/ide/settings/settings.json
@@ -8,6 +8,6 @@
         "**/.gradle": true,
         "**/.sonarlint": true
     },
-    "java.jdt.ls.vmargs": "-noverify -Xmx512m -XX:+UseG1GC -XX:+UseStringDeduplication",
-    "sonarlint.ls.vmargs": "-Xmx512m"
+    "java.jdt.ls.vmargs": "-Xmx128m",
+    "sonarlint.ls.vmargs": "-Xmx128m"
 }

--- a/src/main/kotlin/de/code_freak/codefreak/service/ContainerService.kt
+++ b/src/main/kotlin/de/code_freak/codefreak/service/ContainerService.kt
@@ -36,11 +36,11 @@ class ContainerService(
   /**
    * Memory limit in bytes
    * Equal to --memory-swap in docker run
-   * Default is unlimited
-   * Less than 512MB might cause the IDE to crash
+   * Default is 2GB
+   * Less than 1.5GB might cause the IDE to crash
    */
-  @Value("\${code-freak.docker.memory:0}")
-  var memory = 0L
+  @Value("\${code-freak.docker.memory:2147483648}")
+  var memory = 2147483648L
 
   /**
    * Number of CPUs per container


### PR DESCRIPTION
I left the CPU limit untouched. For me it was very slow with a limit of 1 or 2.
A default Java project now consumes ~1.7GB at the beginning and after a while ~1.5GB.

Closes #87