### PR TITLE
Reduce Docker image size by 1/3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,14 @@ RUN apk add --no-cache gcompat
 
 EXPOSE 8080
 
-COPY --from=build /build/build/libs/ /app
-
 # Run everything as unprivileged user
 RUN addgroup -g 1000 code-freak \
     && adduser -Su 1000 -G code-freak code-freak \
+    && mkdir /app \
     && chown -R code-freak:code-freak /app
+
+COPY --from=build --chown=1000:1000 /build/build/libs/ /app
+
 USER code-freak
 
 # Override this when running the container with -e SPRING_PROFILES_ACTIVE="dev"


### PR DESCRIPTION
Copying the jar to the image and then running chown creates an
intermediate layer with the same jar again (but new owner). So we should
first create the user and then copy the jar with --chown flag.