### PR TITLE
Handle running status and evaluation URL separately

### DIFF
--- a/src/assets/javascripts/assignment.js
+++ b/src/assets/javascripts/assignment.js
@@ -44,10 +44,12 @@ const refreshAssignmentEvaluationStatus = assignmentId => () => {
         pending += 1;
         $button.find('i').attr('class', 'fas fa-spinner fa-pulse');
       } else {
+        $button.find('i').attr('class', 'fas fa-poll');
+      }
+      if (status.url) {
         $button
           .removeClass('disabled')
-          .attr('href', status.url)
-          .find('i').attr('class', 'fas fa-poll');
+          .attr('href', status.url);
       }
     });
     if (pending <= 0) {


### PR DESCRIPTION
Currently the button gets enabled if no evaluation is running
even if there is no evaluation URL