### PR TITLE
Make checkstyle parser work with empty reports

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParser.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParser.kt
@@ -53,7 +53,7 @@ class CheckstyleReportFormatParser(
       checkstyleRoot.files != null -> checkstyleRoot.files.flatMap { checkstyleFileToFeedback(it) }
       checkstyleRoot.errors != null -> checkstyleRoot.errors.map { checkstyleErrorToFeedback(it) }
       checkstyleRoot.exception != null -> listOf(checkstyleExceptionToFeedback(checkstyleRoot.exception))
-      else -> throw EvaluationReportParsingException("Empty checkstyle report")
+      else -> emptyList()
     }
   }
 
@@ -97,12 +97,12 @@ class CheckstyleReportFormatParser(
   data class CheckstyleXmlRoot(
     @JacksonXmlElementWrapper(useWrapping = false)
   @JsonProperty("file")
-  val files: List<CheckstyleFile>?,
+  val files: List<CheckstyleFile>? = null,
     @JacksonXmlElementWrapper(useWrapping = false)
   @JsonProperty("error")
-  val errors: List<CheckstyleError>?,
+  val errors: List<CheckstyleError>? = null,
     @JacksonXmlCData
-  val exception: String?
+  val exception: String? = null
   )
 
   data class CheckstyleFile(

--- a/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParserTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/evaluation/report/CheckstyleReportFormatParserTest.kt
@@ -19,7 +19,8 @@ class CheckstyleReportFormatParserTest {
 
   @Test
   fun parseStandard() {
-    val feedback = parser.parse("""
+    val feedback = parser.parse(
+        """
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="8.45.1">
     <file name="/home/coder/project/src/main/java/Calculator.java">
@@ -70,7 +71,8 @@ class CheckstyleReportFormatParserTest {
    */
   @Test
   fun `parse with exception in file`() {
-    val feedback = parser.parse("""
+    val feedback = parser.parse(
+        """
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
 <file name="Test.java">
@@ -101,7 +103,8 @@ example
    */
   @Test
   fun `parse with exception in root`() {
-    val feedback = parser.parse("""
+    val feedback = parser.parse(
+        """
 <?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="">
 <exception>
@@ -123,5 +126,16 @@ example
             )
         )
     )
+  }
+
+  @Test
+  fun `parse empty works correctly`() {
+    val feedback = parser.parse(
+        """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <checkstyle></checkstyle>
+    """.trimIndent()
+    )
+    MatcherAssert.assertThat(feedback, Matchers.hasSize(0))
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
If e.g. `eslint` generates an empty checkstyle report this should not make the parser fail.
