### PR TITLE
Shut down IDE workspaces that have been idle

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
@@ -120,6 +120,17 @@ class AppConfiguration {
      * Full image name that will be used for the workspace companion
      */
     var companionImage = "ghcr.io/codefreak/codefreak-cloud-companion:minimal"
+
+    /**
+     * Threshold in seconds after which workspaces without any (websocket) connections
+     * are shut down.
+     */
+    var maxIdleThreshold = 60 * 5L
+
+    /**
+     * Interval in seconds how often workspaces are checked for idleness.
+     */
+    var idleCheckInterval = 20L
   }
 
   class Docker {

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManager.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManager.kt
@@ -1,0 +1,92 @@
+package org.codefreak.codefreak.service.workspace
+
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Manager that keeps track of running workspaces and shuts down IDE workspaces that
+ * have been idle for too long.
+ */
+@Component
+class WorkspaceLifecycleManager(
+  /**
+   * Timeout in seconds after which idle workspace will be removed
+   */
+  @Value("#{@config.workspaces.maxIdleThreshold}")
+  private val removeTimeout: Long = 60 * 5L,
+  private val workspaceService: WorkspaceService,
+  private val clientService: WorkspaceClientService
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(WorkspaceLifecycleManager::class.java)
+  }
+
+  var clock: Clock = Clock.systemDefaultZone()
+
+  /**
+   * Registry that holds a time reference of workspace-reference to time when the workspace
+   * has been encountered as idle the first time.
+   */
+  private var idleWorkspaceStore = mapOf<String, Instant>()
+
+  /**
+   * List of workspace purposes that are watched. Only workspaces that are in user-control
+   * should be shut down.
+   */
+  private val watchedPurposes = listOf(
+    WorkspacePurpose.ANSWER_IDE,
+    WorkspacePurpose.TASK_IDE
+  )
+
+  @Scheduled(
+    fixedRateString = "#{@config.workspaces.idleCheckInterval}",
+    initialDelayString = "#{@config.workspaces.idleCheckInterval}"
+  )
+  fun removeIdleWorkspaces() {
+    // keep a fixed "now" for further processing to ignore processing times
+    val now = clock.instant()
+    val removeInstant = now.minusSeconds(removeTimeout)
+    log.debug("Removing workspace(s) that have been idle since $removeInstant (limit is ${removeTimeout}s)")
+    val idleWorkspaces = workspaceService.findAllWorkspaces()
+      .filter { watchedPurposes.contains(it.identifier.purpose) }
+      .mapNotNull { reference ->
+        val client = clientService.createClient(reference)
+        val numWsConnections = try {
+          client.countWebsocketConnections()
+        } catch (e: IllegalStateException) {
+          // ignore workspaces that are in an erroneous state (maybe just started or shutting down)
+          log.debug("Workspace $reference appears to be broken. Ignoring for idle check.")
+          return@mapNotNull null
+        }
+        if (numWsConnections <= 0) {
+          // either take their existing idle time or mark them idle since now
+          val idleSince = idleWorkspaceStore[reference.identifier.hashString()] ?: now
+          Pair(reference.identifier, idleSince)
+        } else {
+          // workspace is not idle (anymore)
+          null
+        }
+      }
+      .toMap()
+      .filter { (identifier, idleSince) ->
+        val idleFor = ChronoUnit.SECONDS.between(idleSince, now)
+        val timeLeft = ChronoUnit.SECONDS.between(removeInstant, idleSince)
+        if (timeLeft <= 0) {
+          log.info("Shutting down workspace ${identifier.hashString()} that has been idle for ${idleFor}s")
+          workspaceService.deleteWorkspace(identifier)
+          false
+        } else {
+          log.debug("Workspace ${identifier.hashString()} has been idle for ${idleFor}s. Will be removed in ${timeLeft}s")
+          true
+        }
+      }
+
+    // store all workspaces that have not been removed this round for the next cycle
+    idleWorkspaceStore = idleWorkspaces.mapKeys { it.key.hashString() }
+  }
+}

--- a/src/test/kotlin/org/codefreak/codefreak/service/WorkspaceBaseTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/WorkspaceBaseTest.kt
@@ -38,6 +38,9 @@ abstract class WorkspaceBaseTest {
   @MockBean
   protected lateinit var fileService: FileService
 
+  @Autowired
+  protected lateinit var appConfiguration: AppConfiguration
+
   protected fun createTarWithEntries(entries: Map<String, String>): InputStream {
     val tarOutput = ByteArrayOutputStream()
     TarUtil.PosixTarArchiveOutputStream(tarOutput).use {

--- a/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceClientTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceClientTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.runBlocking
 import liquibase.util.StreamUtil
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.awaitility.Awaitility.await
-import org.codefreak.codefreak.config.AppConfiguration
 import org.codefreak.codefreak.service.WorkspaceBaseTest
 import org.codefreak.codefreak.util.TarUtil.entrySequence
 import org.hamcrest.MatcherAssert.assertThat
@@ -26,9 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired
 // Can be enabled once the Image building works on GitHub Actions
 @DisabledOnOs(OS.WINDOWS)
 class WorkspaceClientTest : WorkspaceBaseTest() {
-  @Autowired
-  private lateinit var appConfiguration: AppConfiguration
-
   @Autowired
   private lateinit var workspaceClientService: WorkspaceClientService
 

--- a/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManagerTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManagerTest.kt
@@ -1,0 +1,88 @@
+package org.codefreak.codefreak.service.workspace
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import java.io.ByteArrayOutputStream
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility.await
+import org.codefreak.codefreak.service.WorkspaceBaseTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.mockito.Mock
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * Test that a workspace will be removed after 15sec
+ */
+// Can be enabled once the Image building works on GitHub Actions
+@DisabledOnOs(OS.WINDOWS)
+class WorkspaceLifecycleManagerTest : WorkspaceBaseTest() {
+  @Mock
+  private lateinit var clock: Clock
+
+  @Autowired
+  private lateinit var workspaceService: WorkspaceService
+
+  @Autowired
+  private lateinit var clientService: WorkspaceClientService
+
+  private lateinit var lifecycleManager: WorkspaceLifecycleManager
+
+  private val now = Instant.parse("2021-01-01T01:01:01Z")
+
+  private val identifier = WorkspaceIdentifier(
+      purpose = WorkspacePurpose.TASK_IDE,
+      reference = "test-lifecycle-manager"
+    )
+
+  @BeforeEach
+  fun setUp() {
+    whenever(fileService.readCollectionTar(any())).thenReturn(createTarWithEntries(emptyMap()))
+    whenever(fileService.writeCollectionTar(any())).thenReturn(ByteArrayOutputStream())
+    workspaceService.createWorkspace(
+      identifier,
+      WorkspaceConfiguration(
+        collectionId = UUID(0, 0),
+        isReadOnly = false,
+        scripts = emptyMap(),
+        imageName = appConfiguration.workspaces.companionImage
+      )
+    )
+    lifecycleManager = WorkspaceLifecycleManager(removeTimeout = 15, workspaceService, clientService)
+    lifecycleManager.clock = clock
+  }
+
+  @Test
+  fun removeIdleWorkspaces() {
+    // Initial cycle, nothing should happen
+    whenever(clock.instant()).thenReturn(now)
+    lifecycleManager.removeIdleWorkspaces()
+    await().during(10, TimeUnit.SECONDS).timeout(11, TimeUnit.SECONDS).untilAsserted {
+      assertThat(workspaceService.findAllWorkspaces().filter { it.identifier == identifier }, hasSize(1))
+    }
+    // let 10sec pass, nothing should happen
+    whenever(clock.instant()).thenReturn(now.plusSeconds(10))
+    lifecycleManager.removeIdleWorkspaces()
+    await().during(10, TimeUnit.SECONDS).timeout(11, TimeUnit.SECONDS).untilAsserted {
+      assertThat(workspaceService.findAllWorkspaces().filter { it.identifier == identifier }, hasSize(1))
+    }
+    // let another 10sec pass -> workspace should be removed
+    whenever(clock.instant()).thenReturn(now.plusSeconds(20))
+    lifecycleManager.removeIdleWorkspaces()
+    // deletion will take some time
+    await().atMost(20, TimeUnit.SECONDS).untilAsserted {
+      assertThat(workspaceService.findAllWorkspaces().filter { it.identifier == identifier }, hasSize(0))
+    }
+    // make sure files have been saved
+    verify(fileService, times(1)).writeCollectionTar(UUID(0, 0))
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Workspaces that have been idle for too long will be shut down by the lifecycle manager.


## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
