### PR TITLE
Make workspace resource limits configurable

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/config/AppConfiguration.kt
@@ -160,6 +160,21 @@ class AppConfiguration {
      * ```
      */
     var jwkUrl = "http://localhost:8080/.well-known/jwks.json"
+
+    /**
+     * CPU limit of the workspace. Must be a valid value for Kubernetes `spec.containers[].resources.limits.cpu`.
+     *
+     * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers">Kubernetes | Managing Resources for Containers</a>
+     */
+    var cpuLimit = "1"
+
+    /**
+     * Memory limit of the workspace. Must be a valid value for Kubernetes `spec.containers[].resources.limits.memory`.
+     * Currently, no value below 1Gi is recommended. Otherwise, workspaces may crash unexpectedly.
+     *
+     * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers">Kubernetes | Managing Resources for Containers</a>
+     */
+    var memoryLimit = "1Gi"
   }
 
   class Docker {

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/WorkspaceEvaluationBackend.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/WorkspaceEvaluationBackend.kt
@@ -101,7 +101,9 @@ class WorkspaceEvaluationBackend : EvaluationBackend {
       scripts = mapOf(
         EVALUATION_SCRIPT_NAME to runConfig.script
       ),
-      environment = runConfig.environment
+      environment = runConfig.environment,
+      cpuLimit = appConfiguration.workspaces.cpuLimit,
+      memoryLimit = appConfiguration.workspaces.memoryLimit
     )
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceConfiguration.kt
@@ -35,5 +35,19 @@ data class WorkspaceConfiguration(
    * Optional map of additional environment variables that will be available
    * in the workspace.
    */
-  val environment: Map<String, String>? = null
+  val environment: Map<String, String>? = null,
+
+  /**
+   * CPU limit of the workspace. Must be a valid value for Kubernetes `spec.containers[].resources.limits.cpu`.
+   *
+   * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers">Kubernetes | Managing Resources for Containers</a>
+   */
+  val cpuLimit: String = "1",
+
+  /**
+   * Memory limit of the workspace. Must be a valid value for Kubernetes `spec.containers[].resources.limits.memory`.
+   *
+   * @see <a href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers">Kubernetes | Managing Resources for Containers</a>
+   */
+  val memoryLimit: String = "1Gi"
 )

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeService.kt
@@ -1,10 +1,10 @@
 package org.codefreak.codefreak.service.workspace
 
 import java.util.UUID
+import org.codefreak.codefreak.config.AppConfiguration
 import org.codefreak.codefreak.entity.Answer
 import org.codefreak.codefreak.entity.User
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 /**
@@ -16,8 +16,7 @@ class WorkspaceIdeService(
   private val workspaceService: WorkspaceService,
   @Autowired(required = false)
   private val workspaceAuthService: WorkspaceAuthService?,
-  @Value("#{@config.workspaces.companionImage}")
-  private val defaultWorkspaceImage: String
+  private val appConfig: AppConfiguration
 ) {
 
   data class AuthenticatedWorkspaceReference(
@@ -82,7 +81,9 @@ class WorkspaceIdeService(
       collectionId = answer.id,
       isReadOnly = false,
       scripts = emptyMap(),
-      imageName = defaultWorkspaceImage
+      imageName = appConfig.workspaces.companionImage,
+      cpuLimit = appConfig.workspaces.cpuLimit,
+      memoryLimit = appConfig.workspaces.memoryLimit
     )
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/model/WorkspacePodModel.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/model/WorkspacePodModel.kt
@@ -46,12 +46,12 @@ class WorkspacePodModel(
 
         resources {
           requests = mapOf(
-            "cpu" to Quantity.parse("1"),
-            "memory" to Quantity.parse("768Mi")
+            "cpu" to Quantity.parse(wsConfig.cpuLimit),
+            "memory" to Quantity.parse(wsConfig.memoryLimit)
           )
           limits = mapOf(
-            "cpu" to Quantity.parse("1"),
-            "memory" to Quantity.parse("768Mi")
+            "cpu" to Quantity.parse(wsConfig.cpuLimit),
+            "memory" to Quantity.parse(wsConfig.memoryLimit)
           )
         }
 


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :scroll: Description
Replaces the CPU and memory limits with a configurable limit. I raised the default memory limit to 1GiB, otherwise the companion/pod will crash
