### PR TITLE
Refactor workspace file handling

### DIFF
--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/DockerEvaluationBackend.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/DockerEvaluationBackend.kt
@@ -12,7 +12,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.codefreak.codefreak.config.AppConfiguration
 import org.codefreak.codefreak.service.ContainerService
 import org.codefreak.codefreak.service.ExecResult
-import org.codefreak.codefreak.service.file.FileService
 import org.codefreak.codefreak.util.TarUtil
 import org.codefreak.codefreak.util.TarUtil.entrySequence
 import org.codefreak.codefreak.util.preventClose
@@ -35,7 +34,7 @@ class DockerEvaluationBackend : EvaluationBackend {
   private lateinit var containerService: ContainerService
 
   @Autowired
-  private lateinit var fileService: FileService
+  private lateinit var evaluationStepService: EvaluationStepService
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -53,7 +52,7 @@ class DockerEvaluationBackend : EvaluationBackend {
     }
     return containerService.useContainer(containerId) {
       // copy over project files that will be evaluated
-      fileService.readCollectionTar(runConfig.collectionId).use {
+      evaluationStepService.getFilesForEvaluation(runConfig.id).use {
         containerService.copyToContainer(it, containerId, runConfig.workingDirectory)
       }
       // copy all scripts

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationBackend.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationBackend.kt
@@ -50,8 +50,7 @@ typealias EvaluationResultProcessor<T> = (result: EvaluationResult) -> T
  */
 interface EvaluationRunConfig {
   /**
-   * The unique identified for each running evaluation.
-   * Currently, this is the id of the evaluation step, but this might change in the future.
+   * The ID of the EvaluationStep
    */
   val id: UUID
 
@@ -74,9 +73,4 @@ interface EvaluationRunConfig {
    * The name of a directory which should be the working directory when executing the evaluation script.
    */
   val workingDirectory: String
-
-  /**
-   * The collection that will be extracted to the working directory before invoking the evaluation script.
-   */
-  val collectionId: UUID
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepProcessor.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepProcessor.kt
@@ -190,8 +190,7 @@ class EvaluationStepProcessor : ItemProcessor<EvaluationStep, EvaluationStep?> {
         imageName = appConfig.evaluation.defaultImage,
         workingDirectory = appConfig.evaluation.imageWorkdir,
         script = createEvaluationScript(stepDefinition.script),
-        environment = buildEnvVariables(step),
-        collectionId = step.evaluation.answer.id
+        environment = buildEnvVariables(step)
     )
   }
 
@@ -232,7 +231,6 @@ class EvaluationStepProcessor : ItemProcessor<EvaluationStep, EvaluationStep?> {
     override val script: String,
     override val environment: Map<String, String>,
     override val imageName: String,
-    override val workingDirectory: String,
-    override val collectionId: UUID
+    override val workingDirectory: String
   ) : EvaluationRunConfig
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/EvaluationStepService.kt
@@ -1,7 +1,12 @@
 package org.codefreak.codefreak.service.evaluation
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.time.Instant
 import java.util.UUID
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+import org.codefreak.codefreak.entity.Answer
 import org.codefreak.codefreak.entity.Evaluation
 import org.codefreak.codefreak.entity.EvaluationStep
 import org.codefreak.codefreak.entity.EvaluationStepDefinition
@@ -11,6 +16,10 @@ import org.codefreak.codefreak.repository.EvaluationStepRepository
 import org.codefreak.codefreak.service.EntityNotFoundException
 import org.codefreak.codefreak.service.EvaluationStatusUpdatedEvent
 import org.codefreak.codefreak.service.EvaluationStepStatusUpdatedEvent
+import org.codefreak.codefreak.service.file.FileService
+import org.codefreak.codefreak.util.TarUtil
+import org.codefreak.codefreak.util.TaskUtil.isHidden
+import org.codefreak.codefreak.util.TaskUtil.isProtected
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -24,6 +33,9 @@ class EvaluationStepService {
 
   @Autowired
   private lateinit var stepRepository: EvaluationStepRepository
+
+  @Autowired
+  private lateinit var fileService: FileService
 
   fun getEvaluationStep(stepId: UUID): EvaluationStep {
     return stepRepository.findById(stepId).orElseThrow {
@@ -80,5 +92,37 @@ class EvaluationStepService {
 
   fun saveEvaluationStep(step: EvaluationStep) {
     stepRepository.save(step)
+  }
+
+  /**
+   * Get the files needed for running the given evaluation step. The returned archive will contain
+   * the files from the answer overlapped by protected and hidden files.
+   */
+  fun getFilesForEvaluation(evaluationStepId: UUID): InputStream {
+    val evaluationStep = try {
+      getEvaluationStep(evaluationStepId)
+    } catch (e: EntityNotFoundException) {
+      throw IllegalStateException("Cannot load files of evaluation step $evaluationStepId because it does not exist in the database")
+    }
+    return copyFilesForEvaluation(evaluationStep.evaluation.answer)
+  }
+
+  /**
+   * Creates an in-memory tar archive containing the files from the answer overlapped by hidden and protected files.
+   */
+  private fun copyFilesForEvaluation(answer: Answer): InputStream {
+    val out = ByteArrayOutputStream()
+    val outTar = TarUtil.PosixTarArchiveOutputStream(out)
+    fileService.readCollectionTar(answer.id).use { answerFiles ->
+      TarUtil.copyEntries(TarArchiveInputStream(answerFiles), outTar, filter = {
+        !answer.task.isHidden(it) && !answer.task.isProtected(it)
+      })
+    }
+    fileService.readCollectionTar(answer.task.id).use { taskFiles ->
+      TarUtil.copyEntries(TarArchiveInputStream(taskFiles), outTar, filter = {
+        answer.task.isHidden(it) || answer.task.isProtected(it)
+      })
+    }
+    return ByteArrayInputStream(out.toByteArray())
   }
 }

--- a/src/main/kotlin/org/codefreak/codefreak/service/evaluation/WorkspaceEvaluationBackend.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/evaluation/WorkspaceEvaluationBackend.kt
@@ -96,8 +96,6 @@ class WorkspaceEvaluationBackend : EvaluationBackend {
     return WorkspaceConfiguration(
       // TODO: Use image that might has been configured by the eval config
       imageName = appConfiguration.workspaces.companionImage,
-      collectionId = runConfig.collectionId,
-      isReadOnly = true,
       scripts = mapOf(
         EVALUATION_SCRIPT_NAME to runConfig.script
       ),

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/CompositeWorkspaceFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/CompositeWorkspaceFileService.kt
@@ -1,0 +1,46 @@
+package org.codefreak.codefreak.service.workspace
+
+import java.io.InputStream
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Service
+
+/**
+ * WorkspaceFileService that delegates all save and load to a file service responsible for specific `WorkspacePurpose`s.
+ * This is the primary file service but actual save and load operations are implemented in the following classes:
+ * * [WorkspaceIdeFileService]
+ * * [WorkspaceEvaluationFileService]
+ */
+@Primary
+@Service
+class CompositeWorkspaceFileService(
+  delegates: List<ScopedFileWorkspaceService>
+) : WorkspaceFileService {
+  /**
+   * Small extended interface that adds a list of supported WorkspacePurpose to each file service.
+   */
+  interface ScopedFileWorkspaceService : WorkspaceFileService {
+    val supportedPurposes: Set<WorkspacePurpose>
+  }
+
+  /**
+   * Create a map of WorkspacePurpose to WorkspaceFileService by the list of delegates.
+   * Duplicates are ignored silently.
+   */
+  private val delegatedFileServices: Map<WorkspacePurpose, WorkspaceFileService> =
+    delegates.flatMap { delegate -> delegate.supportedPurposes.map { purpose -> Pair(purpose, delegate) } }.toMap()
+
+  override fun loadFiles(identifier: WorkspaceIdentifier, filesConsumer: Consumer<InputStream>) {
+    getDelegate(identifier).loadFiles(identifier, filesConsumer)
+  }
+
+  override fun saveFiles(identifier: WorkspaceIdentifier, filesSupplier: Supplier<InputStream>) {
+    getDelegate(identifier).saveFiles(identifier, filesSupplier)
+  }
+
+  private fun getDelegate(identifier: WorkspaceIdentifier): WorkspaceFileService {
+    return delegatedFileServices[identifier.purpose]
+      ?: throw IllegalArgumentException("Workspace purpose ${identifier.purpose} is not supported")
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceConfiguration.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceConfiguration.kt
@@ -1,24 +1,9 @@
 package org.codefreak.codefreak.service.workspace
 
-import java.util.UUID
-
 /**
  * Interface for describing the demand for a Workspace
  */
 data class WorkspaceConfiguration(
-  /**
-   * Collection-ID that will be used for reading/writing files from/to a workspace.
-   * If the workspace is marked as read-only the collection will only be extracted
-   * and not stored back to the database.
-   */
-  val collectionId: UUID,
-
-  /**
-   * Indicate if this workspace is read-only, meaning the files will not be saved
-   * back to the database.
-   */
-  val isReadOnly: Boolean,
-
   /**
    * Map of executable name to content of scripts that will be added to PATH
    */

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceEvaluationFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceEvaluationFileService.kt
@@ -1,0 +1,28 @@
+package org.codefreak.codefreak.service.workspace
+
+import java.io.InputStream
+import java.util.UUID
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.codefreak.codefreak.service.evaluation.EvaluationStepService
+import org.codefreak.codefreak.service.workspace.CompositeWorkspaceFileService.ScopedFileWorkspaceService
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.EVALUATION
+import org.springframework.stereotype.Service
+
+/**
+ * Workspace file service for evaluations that will load the files via [EvaluationStepService].
+ */
+@Service
+class WorkspaceEvaluationFileService(
+  private val evaluationStepService: EvaluationStepService
+) : ScopedFileWorkspaceService {
+  override val supportedPurposes = setOf(EVALUATION)
+
+  override fun loadFiles(identifier: WorkspaceIdentifier, filesConsumer: Consumer<InputStream>) {
+    evaluationStepService.getFilesForEvaluation(UUID.fromString(identifier.reference)).use(filesConsumer::accept)
+  }
+
+  override fun saveFiles(identifier: WorkspaceIdentifier, filesSupplier: Supplier<InputStream>) {
+    // Saving files from evaluations back to database is not supported
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceFileService.kt
@@ -1,0 +1,21 @@
+package org.codefreak.codefreak.service.workspace
+
+import java.io.InputStream
+import java.util.function.Consumer
+import java.util.function.Supplier
+
+/**
+ * Interface for services that provide and save files for workspaces.
+ * The underlying file-structure for the streams are tar archives.
+ */
+interface WorkspaceFileService {
+  /**
+   * Provide a tar archive to the consumer that will be written to the workspace.
+   */
+  fun loadFiles(identifier: WorkspaceIdentifier, filesConsumer: Consumer<InputStream>)
+
+  /**
+   * Accept the files read from the workspace to store it back to the database.
+   */
+  fun saveFiles(identifier: WorkspaceIdentifier, filesSupplier: Supplier<InputStream>)
+}

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeFileService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeFileService.kt
@@ -1,0 +1,33 @@
+package org.codefreak.codefreak.service.workspace
+
+import java.io.InputStream
+import java.util.UUID
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.codefreak.codefreak.service.file.FileService
+import org.codefreak.codefreak.service.workspace.CompositeWorkspaceFileService.ScopedFileWorkspaceService
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.ANSWER_IDE
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.TASK_IDE
+import org.springframework.stereotype.Service
+import org.springframework.util.StreamUtils
+
+/**
+ * Workspace file service that is responsible for answer and task IDEs. It tries to load/save by the UUID saved in
+ * the workspace identifier reference field.
+ */
+@Service
+class WorkspaceIdeFileService(
+  private val fileService: FileService
+) : ScopedFileWorkspaceService {
+  override val supportedPurposes = setOf(ANSWER_IDE, TASK_IDE)
+
+  override fun loadFiles(identifier: WorkspaceIdentifier, filesConsumer: Consumer<InputStream>) {
+    fileService.readCollectionTar(UUID.fromString(identifier.reference)).use(filesConsumer::accept)
+  }
+
+  override fun saveFiles(identifier: WorkspaceIdentifier, filesSupplier: Supplier<InputStream>) {
+    fileService.writeCollectionTar(UUID.fromString(identifier.reference)).use {
+      StreamUtils.copy(filesSupplier.get(), it)
+    }
+  }
+}

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeService.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceIdeService.kt
@@ -31,7 +31,7 @@ class WorkspaceIdeService(
    */
   fun createAnswerIdeForUser(answer: Answer, user: User): AuthenticatedWorkspaceReference {
     val identifier = createAnswerIdeWorkspaceIdentifier(answer.id)
-    val config = createAnswerIdeWorkspaceConfig(answer)
+    val config = createAnswerIdeWorkspaceConfig()
     val remoteReference = workspaceService.createWorkspace(identifier, config)
     return AuthenticatedWorkspaceReference(remoteReference, workspaceAuthService?.createUserAuthToken(identifier, user))
   }
@@ -41,7 +41,7 @@ class WorkspaceIdeService(
    */
   fun createAnswerIde(answer: Answer): RemoteWorkspaceReference {
     val identifier = createAnswerIdeWorkspaceIdentifier(answer.id)
-    val config = createAnswerIdeWorkspaceConfig(answer)
+    val config = createAnswerIdeWorkspaceConfig()
     return workspaceService.createWorkspace(identifier, config)
   }
 
@@ -77,10 +77,8 @@ class WorkspaceIdeService(
     )
   }
 
-  private fun createAnswerIdeWorkspaceConfig(answer: Answer): WorkspaceConfiguration {
+  private fun createAnswerIdeWorkspaceConfig(): WorkspaceConfiguration {
     return WorkspaceConfiguration(
-      collectionId = answer.id,
-      isReadOnly = false,
       scripts = emptyMap(),
       imageName = defaultWorkspaceImage
     )

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/k8s_extensions.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/k8s_extensions.kt
@@ -1,26 +1,14 @@
 package org.codefreak.codefreak.service.workspace
 
 import io.fabric8.kubernetes.api.model.Pod
-import java.util.UUID
 
 const val WS_K8S_LABEL_REFERENCE = "org.codefreak.reference"
 const val WS_K8S_LABEL_PURPOSE = "org.codefreak.purpose"
-const val WS_K8S_LABEL_COLLECTION_ID = "org.codefreak.collection-id"
-const val WS_K8S_LABEL_READONLY = "org.codefreak.read-only"
 
 val WorkspaceIdentifier.k8sLabels
   get() = mapOf(
     WS_K8S_LABEL_REFERENCE to reference,
     WS_K8S_LABEL_PURPOSE to purpose.key
-  )
-
-/**
- * TODO: Store configuration in secret and not as labels
- */
-val WorkspaceConfiguration.k8sLabels
-  get() = mapOf(
-    WS_K8S_LABEL_COLLECTION_ID to collectionId.toString(),
-    WS_K8S_LABEL_READONLY to if (isReadOnly) "true" else "false"
   )
 
 val Pod.reference: String
@@ -36,14 +24,6 @@ val Pod.toWorkspaceIdentifier: WorkspaceIdentifier
     purpose = WorkspacePurpose.fromKey(purpose),
     reference = reference
   )
-
-val Pod.isReadOnly: Boolean
-  get() = this.metadata.labels[WS_K8S_LABEL_READONLY]?.let { it == "true" }
-    ?: throw IllegalStateException("Given pod ${this.metadata.name} does not look like a workspace pod")
-
-val Pod.collectionId: UUID
-  get() = this.metadata.labels[WS_K8S_LABEL_COLLECTION_ID]?.let { UUID.fromString(it) }
-    ?: throw IllegalStateException("Given pod ${this.metadata.name} does not look like a workspace pod")
 
 // Service names are limited to 63 characters and must be a valid DNS-1035 identifier...
 val WorkspaceIdentifier.workspaceServiceName: String

--- a/src/main/kotlin/org/codefreak/codefreak/service/workspace/model/WorkspacePodModel.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/service/workspace/model/WorkspacePodModel.kt
@@ -30,8 +30,7 @@ class WorkspacePodModel(
   init {
     metadata {
       name = identifier.workspacePodName
-      // TODO: Store configuration in secret
-      labels = identifier.k8sLabels + wsConfig.k8sLabels
+      labels = identifier.k8sLabels
     }
     spec {
       containers = listOf(newContainer {

--- a/src/main/kotlin/org/codefreak/codefreak/util/TaskUtil.kt
+++ b/src/main/kotlin/org/codefreak/codefreak/util/TaskUtil.kt
@@ -1,0 +1,20 @@
+package org.codefreak.codefreak.util
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry
+import org.codefreak.codefreak.entity.Task
+
+object TaskUtil {
+  fun Task.isHidden(entry: TarArchiveEntry): Boolean {
+    hiddenFiles.plus("codefreak.yml").forEach {
+      if (FileUtil.matches(it, entry.name)) return true
+    }
+    return false
+  }
+
+  fun Task.isProtected(entry: TarArchiveEntry): Boolean {
+    protectedFiles.forEach {
+      if (FileUtil.matches(it, entry.name)) return true
+    }
+    return false
+  }
+}

--- a/src/test/kotlin/org/codefreak/codefreak/service/workspace/CompositeWorkspaceFileServiceTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/workspace/CompositeWorkspaceFileServiceTest.kt
@@ -1,0 +1,79 @@
+package org.codefreak.codefreak.service.workspace
+
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.util.function.Consumer
+import java.util.function.Supplier
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.ANSWER_IDE
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.EVALUATION
+import org.codefreak.codefreak.service.workspace.WorkspacePurpose.TASK_IDE
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+
+class CompositeWorkspaceFileServiceTest {
+  private val emptyInputStream = ByteArrayInputStream(ByteArray(0))
+
+  @Test
+  fun `save is delegated correctly`() {
+    val fs1 = mock(CompositeWorkspaceFileService.ScopedFileWorkspaceService::class.java)
+    whenever(fs1.supportedPurposes).thenReturn(setOf(ANSWER_IDE, TASK_IDE))
+    val fs2 = mock(CompositeWorkspaceFileService.ScopedFileWorkspaceService::class.java)
+    whenever(fs2.supportedPurposes).thenReturn(setOf(EVALUATION))
+
+    val id1 = WorkspaceIdentifier(ANSWER_IDE, "foo1")
+    val supplier1 = Supplier<InputStream> { emptyInputStream }
+    val id2 = WorkspaceIdentifier(TASK_IDE, "foo2")
+    val supplier2 = Supplier<InputStream> { emptyInputStream }
+    val id3 = WorkspaceIdentifier(EVALUATION, "foo3")
+    val supplier3 = Supplier<InputStream> { emptyInputStream }
+
+    val compositeWorkspaceFileService = CompositeWorkspaceFileService(listOf(fs1, fs2))
+    compositeWorkspaceFileService.saveFiles(id1, supplier1)
+    compositeWorkspaceFileService.saveFiles(id2, supplier2)
+    compositeWorkspaceFileService.saveFiles(id3, supplier3)
+
+    verify(fs1, times(1)).saveFiles(id1, supplier1)
+    verify(fs1, times(1)).saveFiles(id2, supplier2)
+    verify(fs2, times(1)).saveFiles(id3, supplier3)
+  }
+
+  @Test
+  fun `load is delegated correctly`() {
+    val fs1 = mock(CompositeWorkspaceFileService.ScopedFileWorkspaceService::class.java)
+    whenever(fs1.supportedPurposes).thenReturn(setOf(ANSWER_IDE, TASK_IDE))
+    val fs2 = mock(CompositeWorkspaceFileService.ScopedFileWorkspaceService::class.java)
+    whenever(fs2.supportedPurposes).thenReturn(setOf(EVALUATION))
+    val id1 = WorkspaceIdentifier(ANSWER_IDE, "foo1")
+    val consumer1 = Consumer<InputStream> { assertSame(it, emptyInputStream) }
+    val id2 = WorkspaceIdentifier(TASK_IDE, "foo2")
+    val consumer2 = Consumer<InputStream> { assertSame(it, emptyInputStream) }
+    val id3 = WorkspaceIdentifier(EVALUATION, "foo3")
+    val consumer3 = Consumer<InputStream> { assertSame(it, emptyInputStream) }
+
+    val compositeWorkspaceFileService = CompositeWorkspaceFileService(listOf(fs1, fs2))
+    compositeWorkspaceFileService.loadFiles(id1, consumer1)
+    compositeWorkspaceFileService.loadFiles(id2, consumer2)
+    compositeWorkspaceFileService.loadFiles(id3, consumer3)
+
+    verify(fs1, times(1)).loadFiles(id1, consumer1)
+    verify(fs1, times(1)).loadFiles(id2, consumer2)
+    verify(fs2, times(1)).loadFiles(id3, consumer3)
+  }
+
+  @Test
+  fun `throws when no delegate is available`() {
+    val compositeWorkspaceFileService = CompositeWorkspaceFileService(emptyList())
+    assertThrows(IllegalArgumentException::class.java) {
+      compositeWorkspaceFileService.saveFiles(WorkspaceIdentifier(ANSWER_IDE, "foo1")) { emptyInputStream }
+    }
+
+    assertThrows(IllegalArgumentException::class.java) {
+      compositeWorkspaceFileService.loadFiles(WorkspaceIdentifier(ANSWER_IDE, "foo1")) { /* no-op */ }
+    }
+  }
+}

--- a/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceClientTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceClientTest.kt
@@ -40,8 +40,6 @@ class WorkspaceClientTest : WorkspaceBaseTest() {
     remoteWorkspaceReference = workspaceService.createWorkspace(
       workspaceIdentifier,
       WorkspaceConfiguration(
-        collectionId = collectionId,
-        isReadOnly = true,
         scripts = emptyMap(),
         imageName = appConfiguration.workspaces.companionImage
       )

--- a/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManagerTest.kt
+++ b/src/test/kotlin/org/codefreak/codefreak/service/workspace/WorkspaceLifecycleManagerTest.kt
@@ -33,9 +33,9 @@ class WorkspaceLifecycleManagerTest : WorkspaceBaseTest() {
   private val now = Instant.parse("2021-01-01T01:01:01Z")
 
   private val identifier = WorkspaceIdentifier(
-      purpose = WorkspacePurpose.TASK_IDE,
-      reference = "test-lifecycle-manager"
-    )
+    purpose = WorkspacePurpose.TASK_IDE,
+    reference = UUID(0, 0).toString()
+  )
 
   @BeforeEach
   fun setUp() {
@@ -44,8 +44,6 @@ class WorkspaceLifecycleManagerTest : WorkspaceBaseTest() {
     workspaceService.createWorkspace(
       identifier,
       WorkspaceConfiguration(
-        collectionId = UUID(0, 0),
-        isReadOnly = false,
         scripts = emptyMap(),
         imageName = appConfiguration.workspaces.companionImage
       )


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
This refactoring will also fix a the bug that hidden and protected files are missing in evaluations.  
Loading and saving files from/to workspaces are now handled by delegated services. This decouples the `WorkspaceService` (again) from our `FileService`.
