### PR TITLE
Remove the use of a query subpath for the evaluation page tabs

### DIFF
--- a/client/src/pages/evaluation/EvaluationOverviewPage.tsx
+++ b/client/src/pages/evaluation/EvaluationOverviewPage.tsx
@@ -1,8 +1,6 @@
 import { Tabs } from 'antd'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import EvaluationHistory from '../../components/EvaluationHistory'
-import useSubPath from '../../hooks/useSubPath'
-import { shorten } from '../../services/short-id'
 import { DifferentUserContext } from '../task/TaskPage'
 import LatestEvaluation from '../../components/LatestEvaluation'
 
@@ -11,19 +9,14 @@ const { TabPane } = Tabs
 const EvaluationPage: React.FC<{
   answerId: string
 }> = ({ answerId }) => {
-  const subPath = useSubPath()
+  const [activeTab, setActiveTab] = useState('')
   const differentUser = useContext(DifferentUserContext)
 
-  const onTabChange = (activeKey: string) => {
-    subPath.set(
-      activeKey,
-      differentUser ? { user: shorten(differentUser.id) } : undefined
-    )
-  }
+  const onTabChange = (activeKey: string) => setActiveTab(activeKey)
 
   return (
     <>
-      <Tabs defaultActiveKey={subPath.get()} onChange={onTabChange}>
+      <Tabs defaultActiveKey={activeTab} onChange={onTabChange}>
         <TabPane tab="Latest Evaluation" key="">
           <LatestEvaluation answerId={answerId} showTrigger={!differentUser} />
         </TabPane>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->
Fixes an issue with the evaluation page and the workspaces IDE since they both use tabs and the url.

## :ballot_box_with_check: Checklist:

- [x] I have performed a self-review of my own code
- [x] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
