### PR TITLE
Fix build and remove incompatible Traefik proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,6 @@
 
 version: "3"
 services:
-  proxy:
-    image: traefik:v1.7
-    ports:
-      - "8081:80"
-    command: "--docker --docker.exposedbydefault=false --docker.watch=true"
-    network_mode: bridge
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
   frontend:
     depends_on:
       - backend
@@ -44,6 +36,8 @@ services:
     working_dir: /home/gradle/project
     networks:
       - private
+    ports:
+      - "8080:8080"
     volumes:
       - ".:/home/gradle/project"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 pluginManagement {
   repositories {
     gradlePluginPortal()
+    mavenCentral()
   }
 }
 rootProject.name = 'codefreak'


### PR DESCRIPTION
- Add mavenCentral() to pluginManagement repositories to resolve missing grgit-core:4.1.0 dependency
- Remove Traefik v1.7 proxy (incompatible with Docker 29.x) and expose backend directly on port 8080

## :loudspeaker: Type of change
<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## :scroll: Description
<!--
Please include a short summary of the change.
If it is a new feature tell is why we would need this.
-->

## :link: Related Issues
* Fixes # (issue)

## :ballot_box_with_check: Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run the auto code formatting scripts <!-- npm run fix, gradle spotlessApply -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I updated the `CHANGELOG.md`
- [ ] I have added tests that prove my fix is effective or that my feature works
